### PR TITLE
Update standings.html

### DIFF
--- a/CTFd/themes/admin/templates/scoreboard/standings.html
+++ b/CTFd/themes/admin/templates/scoreboard/standings.html
@@ -1,55 +1,91 @@
 <table id="scoreboard" class="table table-striped border">
-	<thead>
-		<tr>
-			<th class="border-right" data-checkbox>
-				<div class="form-check text-center">
-					<input type="checkbox" class="form-check-input" id="scoreboard-bulk-select" autocomplete="off" data-checkbox-all>&nbsp;
-				</div>
-			</th>
-			<th class="sort-col text-center"><b>Place</b></th>
-			<th class="sort-col"><b>{{ get_mode_as_word(capitalize=True) }}</b></th>
-			<th class="sort-col"><b>Bracket</b></th>
-			<th class="sort-col"><b>Score</b></th>
-			<th class="sort-col"><b>Visibility</b></th>
-		</tr>
-	</thead>
-	<tbody>
-	{% for standing in standings %}
-		<tr data-href="{{ generate_account_url(standing.account_id, admin=True) }}">
-			<td class="border-right text-center" data-checkbox>
-				<div class="form-check">
-					<input type="checkbox" class="form-check-input" value="{{ standing.account_id }}" data-account-id="{{ standing.account_id }}" autocomplete="off">&nbsp;
-				</div>
-			</td>
-			<td class="text-center" width="10%">{{ loop.index }}</td>
-			<td>
-				<a href="{{ generate_account_url(standing.account_id, admin=True) }}">
-					{{ standing.name }}
-					{% if standing.oauth_id %}
-						{% if get_config('user_mode') == 'teams' %}
-							<a href="https://majorleaguecyber.org/t/{{ standing.name }}">
-								<span class="badge badge-primary">Official</span>
-							</a>
-						{% elif get_config('user_mode') == 'users' %}
-							<a href="https://majorleaguecyber.org/u/{{ standing.name }}">
-								<span class="badge badge-primary">Official</span>
-							</a>
-						{% endif %}
-					{% endif %}
-				</a>
-			</td>
-			<td>
-				<span class="badge badge-secondary">{{ standing.bracket_name }}</span>
-			</td>
-			<td>{{ standing.score }}</td>
-			<td>
-				{% if standing.hidden %}
-					<span class="badge badge-danger">hidden</span>
-				{% else %}
-					<span class="badge badge-success">visible</span>
-				{% endif %}
-			</td>
-		</tr>
-	{% endfor %}
-	</tbody>
+  <thead>
+    <tr>
+      <th class="border-right" data-checkbox>
+        <div class="form-check text-center">
+          <input
+            type="checkbox"
+            class="form-check-input"
+            id="scoreboard-bulk-select"
+            autocomplete="off"
+            data-checkbox-all
+          />&nbsp;
+        </div>
+      </th>
+      <th class="sort-col text-center"><b>Place</b></th>
+      <th class="sort-col"><b>{{ get_mode_as_word(capitalize=True) }}</b></th>
+      <th class="sort-col"><b>Institute</b></th>
+      <th class="sort-col"><b>Score</b></th>
+      <th class="sort-col"><b>Visibility</b></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if standings | length == 0 %}
+    <tr>
+      <td colspan="6" class="text-center">No standings available.</td>
+      <!-- Ensure colspan matches the number of columns -->
+    </tr>
+    {% else %} {% set unique_scores = standings | map(attribute='score') |
+    unique | sort(reverse=True) %} {% set gold_score = unique_scores[0] if
+    unique_scores | length > 0 else None %} {% set silver_score =
+    unique_scores[1] if unique_scores | length > 1 else None %} {% set
+    bronze_score = unique_scores[2] if unique_scores | length > 2 else None %}
+    {% for standing in standings %}
+    <!-- Changed from user_standings to standings -->
+    <tr data-href="{{ generate_account_url(standing.account_id, admin=True) }}">
+      <td class="border-right text-center" data-checkbox>
+        <div class="form-check">
+          <input
+            type="checkbox"
+            class="form-check-input"
+            value="{{ standing.account_id }}"
+            data-account-id="{{ standing.account_id }}"
+            autocomplete="off"
+          />&nbsp;
+        </div>
+      </td>
+      <td class="text-center" width="10%">
+        {% if standing.score == gold_score %}
+        <span class="badge badge-warning">🥇 Gold</span>
+        {% elif standing.score == silver_score %}
+        <span class="badge badge-secondary">🥈 Silver</span>
+        {% elif standing.score == bronze_score %}
+        <span class="badge badge-bronze">🥉 Bronze</span>
+        {% else %} {{ loop.index }} {% endif %}
+      </td>
+      <td>
+        <a href="{{ generate_account_url(standing.account_id, admin=True) }}">
+          {{ standing.name }} {% if standing.oauth_id %} {% if
+          get_config('user_mode') == 'teams' %}
+          <a href="https://majorleaguecyber.org/t/{{ standing.name }}">
+            <span class="badge badge-primary">Official</span>
+          </a>
+          {% elif get_config('user_mode') == 'users' %}
+          <a href="https://majorleaguecyber.org/u/{{ standing.name }}">
+            <span class="badge badge-primary">Official</span>
+          </a>
+          {% endif %} {% endif %}
+        </a>
+      </td>
+      <td class="team-affiliation">
+        {% if standing.affiliation %}
+        <span
+          class="d-block text-muted"
+          style="font-size: 12px; background: none"
+        >
+          {{ standing.affiliation }}
+        </span>
+        {% endif %}
+      </td>
+      <td>{{ standing.score }}</td>
+      <td>
+        {% if standing.hidden %}
+        <span class="badge badge-danger">hidden</span>
+        {% else %}
+        <span class="badge badge-success">visible</span>
+        {% endif %}
+      </td>
+    </tr>
+    {% endfor %} {% endif %}
+  </tbody>
 </table>


### PR DESCRIPTION
## Summary by Sourcery

Update the admin scoreboard template to add an empty-state message, highlight top scorers with medal badges, and replace the bracket column with an institute affiliation column while preserving numeric ranks for other positions.

Enhancements:
- Show a “No standings available” row when there are no standings
- Display 🥇, 🥈, and 🥉 medal badges for the top three scorers instead of their numeric positions
- Replace the Bracket column with an Institute column that displays team affiliations
- Keep numeric rankings for positions beyond the top three