### PR TITLE
fixed scoreboard issue

### DIFF
--- a/CTFd/api/v1/scoreboard.py
+++ b/CTFd/api/v1/scoreboard.py
@@ -23,7 +23,7 @@ scoreboard_namespace = Namespace(
 class ScoreboardList(Resource):
     @check_account_visibility
     @check_score_visibility
-    @cache.cached(timeout=60, key_prefix=make_cache_key)
+    @cache.cached(timeout=5, key_prefix=make_cache_key)
     def get(self):
         standings = get_standings()
         response = []

--- a/CTFd/themes/admin/assets/js/pages/scoreboard.js
+++ b/CTFd/themes/admin/assets/js/pages/scoreboard.js
@@ -196,8 +196,7 @@ function renderScoreboard(data) {
   $(".scoreboard-toggle").off().click(toggleAccount);
 }
 
-$(() => {
-  // Initial load of scoreboard data from API
+function updateScoreboard() {
   CTFd.api
     .get_scoreboard()
     .then((response) => {
@@ -216,6 +215,12 @@ $(() => {
         '<tr><td colspan="6" class="text-center text-danger">Error loading scoreboard data.</td></tr>'
       );
     });
+}
+
+$(() => {
+  updateScoreboard();
+
+  setInterval(updateScoreboard, 30000);
 
   // Setup toggle buttons and bulk toggle button
   $(document).on("click", ".scoreboard-toggle", toggleAccount);

--- a/CTFd/themes/core-beta/assets/js/challenges.js
+++ b/CTFd/themes/core-beta/assets/js/challenges.js
@@ -221,33 +221,53 @@ Alpine.data("ChallengeBoard", () => ({
   },
 
   getCategories() {
-    const categories = [];
-    const categoryMap = {};
-
+    const categories = {};
     this.challenges.forEach(challenge => {
-      // Normalize to lower case for grouping
-      const normalized = challenge.category.trim().toLowerCase();
-      if (!categoryMap[normalized]) {
-        categoryMap[normalized] = challenge.category; // Store original for display
-        categories.push(normalized);
+      const category = challenge.category.trim();
+      const normalized = category.toLowerCase();
+      if (!categories[normalized]) {
+        categories[normalized] = category;
       }
     });
+    const categoryNames = Object.values(categories);
 
-    // Optionally sort categories here
+    try {
+      const f = CTFd.config.themeSettings.challenge_category_order;
+      if (f) {
+        const getSort = new Function(`return (${f})`);
+        categoryNames.sort(getSort());
+      }
+    } catch (error) {
+      // Ignore errors with theme category sorting
+      console.log("Error running challenge_category_order function");
+      console.log(error);
+    }
 
-    // Return array of objects: { key: normalized, display: original }
-    return categories.map(key => ({
-      key,
-      display: categoryMap[key]
-    }));
+    return categoryNames;
   },
 
-  getChallenges(categoryObj) {
-    if (!categoryObj) return [];
-    const normalized = categoryObj.key;
-    return this.challenges.filter(
-      challenge => challenge.category.trim().toLowerCase() === normalized
-    );
+  getChallenges(category) {
+    let challenges = this.challenges;
+
+    if (category !== null) {
+      challenges = this.challenges.filter(
+        (challenge) => challenge.category.toLowerCase() === category.toLowerCase()
+      );
+    }
+
+    try {
+      const f = CTFd.config.themeSettings.challenge_order;
+      if (f) {
+        const getSort = new Function(`return (${f})`);
+        challenges.sort(getSort());
+      }
+    } catch (error) {
+      // Ignore errors with theme challenge sorting
+      console.log("Error running challenge_order function");
+      console.log(error);
+    }
+
+    return challenges;
   },
 
   async loadChallenges() {
@@ -273,7 +293,7 @@ Alpine.data("ChallengeBoard", () => ({
           { once: true },
         );
         modal.show();
-        history.replaceState(null, null, #${challenge.data.name}-${challengeId});
+        history.replaceState(null, null, `#${challenge.data.name}-${challengeId}`);
       });
     });
   },

--- a/CTFd/themes/core-beta/assets/js/scoreboard.js
+++ b/CTFd/themes/core-beta/assets/js/scoreboard.js
@@ -7,7 +7,7 @@ window.Alpine = Alpine;
 window.CTFd = CTFd;
 
 // Default scoreboard polling interval to every 5 minutes
-const scoreboardUpdateInterval = window.scoreboardUpdateInterval || 300000;
+const scoreboardUpdateInterval = window.scoreboardUpdateInterval || 30000;
 
 Alpine.data("ScoreboardDetail", () => ({
   data: {},


### PR DESCRIPTION
## Summary by Sourcery

Improve challenge board data handling with simplified category mapping and customizable sorting, fix modal URL hash generation, and enhance scoreboard responsiveness by standardizing auto-refresh intervals and reducing API cache timeout

Bug Fixes:
- Fix URL hash interpolation for challenge modals

Enhancements:
- Refactor challenge board category and challenge retrieval to use normalized string keys and return flat arrays
- Support custom challenge_category_order and challenge_order functions for theme-based sorting
- Standardize scoreboard auto-refresh interval to 30 seconds in both admin and core theme
- Extract updateScoreboard function in admin panel to enable periodic scoreboard updates