### PR TITLE
This GitHub Actions workflow deploys CTFd to an EC2 instance using SSH and Docker Compose

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,4 @@
+# This GitHub Actions workflow deploys CTFd to an EC2 instance using SSH and Docker Compose.
 name: Deploy CTFd to EC2
 
 on:
@@ -24,3 +25,4 @@ jobs:
             git pull origin main
             docker compose down
             docker compose up -d --build
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-name: Deploy CTFd to EC2
+name: Auto Deploy to EC2
 
 on:
   push:
     branches:
-      - gaurav  # 👈 triggers only when you push to gaurav branch
+      - gaurav  # 👈 Trigger this on push to your branch
 
 jobs:
   deploy:
@@ -20,7 +20,8 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
           script: |
-            cd CTFd  # Change if your repo directory is different
+            cd CTFd || git clone https://github.com/gaurav0973/CTFd.git && cd CTFd
+            git checkout gaurav
             git pull origin gaurav
             docker compose down
             docker compose up -d --build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
-# This GitHub Actions workflow deploys CTFd to an EC2 instance using SSH and Docker Compose.
 name: Deploy CTFd to EC2
 
 on:
   push:
     branches:
-      - main
+      - gaurav  # 👈 triggers only when you push to gaurav branch
 
 jobs:
   deploy:
@@ -21,8 +20,7 @@ jobs:
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
           script: |
-            cd CTFd
-            git pull origin main
+            cd CTFd  # Change if your repo directory is different
+            git pull origin gaurav
             docker compose down
             docker compose up -d --build
-

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_KEY }}
+          debug: true
           script: |
             cd CTFd || git clone https://github.com/gaurav0973/CTFd.git && cd CTFd
             git checkout gaurav

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy CTFd to EC2
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: SSH into EC2 and deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USER }}
+          key: ${{ secrets.EC2_KEY }}
+          script: |
+            cd CTFd
+            git pull origin main
+            docker compose down
+            docker compose up -d --build

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ SQLAlchemy==1.4.48
 SQLAlchemy-Utils==0.41.1
 passlib==1.7.4
 bcrypt==4.0.1
-requests==2.32.3
+requests==2.32.4
 PyMySQL[rsa]==1.0.2
 gunicorn==23.0.0
 dataset==1.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,7 +147,7 @@ pytz==2020.4
     #   flask-restx
 redis==4.5.5
     # via -r requirements.in
-requests==2.32.3
+requests==2.32.4
     # via -r requirements.in
 s3transfer==0.10.0
     # via boto3


### PR DESCRIPTION
This GitHub Actions workflow deploys CTFd to an EC2 instance using SSH and Docker Compose

## Summary by Sourcery

Add a GitHub Actions workflow for deploying CTFd to EC2 via SSH and Docker Compose and bump the requests dependency version

Build:
- Update requests dependency from 2.32.3 to 2.32.4

CI:
- Add GitHub Actions workflow to deploy CTFd to an EC2 instance via SSH and Docker Compose on pushes to main